### PR TITLE
Remove backslash escaping in 2024-08-24 post.

### DIFF
--- a/_posts/2024-08-24-news-roundup.md
+++ b/_posts/2024-08-24-news-roundup.md
@@ -7,9 +7,9 @@ tags: [tritag]
 pin: false
 ---
 
-It’s been a few years, but TriTAG is back\! There’s been much progress in the tri-cities but there’s still a lot of work to be done to make Waterloo Region a place where walking, biking, and transit are great ways for most people to get around.
+It’s been a few years, but TriTAG is back! There’s been much progress in the tri-cities but there’s still a lot of work to be done to make Waterloo Region a place where walking, biking, and transit are great ways for most people to get around.
 
-We’ve started working on identifying priority advocacy areas, updating our organizational approach, and replacing our website. We’ll have more to share over time, but for now we’re excited to be back in the game\! Without further ado, here’s some of the latest news:
+We’ve started working on identifying priority advocacy areas, updating our organizational approach, and replacing our website. We’ll have more to share over time, but for now we’re excited to be back in the game! Without further ado, here’s some of the latest news:
 
 ## What's happening
 
@@ -17,20 +17,20 @@ We’ve started working on identifying priority advocacy areas, updating our org
 
 ## Walking, biking, and Vision Zero
 
-* Region of Waterloo council committees are hearing staff recommendations on Thursday for expanded implementation of automated speed enforcement. This includes the [by-laws for appeal administration](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=1210a2a7-c46e-4c67-bbf3-485329cecfa6\&Agenda=Agenda\&lang=English\&Item=47\&Tab=attachments) and a [methodology for identifying locations for enforcement](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=d646b7bf-9c51-4fa1-a80b-2b0b682a8c06\&Agenda=Agenda\&lang=English\&Item=22\&Tab=attachments). Staff are recommending using a complex warrant system based on eligibility and risk factors to designate Community Safety Zones, and to have automated speed enforcement in all such areas. This is for Regional roads only, but staff expect lower-tier municipalities to follow the Region’s lead.  
-* Kitchener is making a [long list of Vision Zero updates](https://www.engagewr.ca/visionzero/news\_feed/2024-hot-spot-improvements) this year to address hot spots, notably including raised crosswalks and pedestrian crossovers.  
+* Region of Waterloo council committees are hearing staff recommendations on Thursday for expanded implementation of automated speed enforcement. This includes the [by-laws for appeal administration](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=1210a2a7-c46e-4c67-bbf3-485329cecfa6&Agenda=Agenda&lang=English&Item=47&Tab=attachments) and a [methodology for identifying locations for enforcement](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=d646b7bf-9c51-4fa1-a80b-2b0b682a8c06&Agenda=Agenda&lang=English&Item=22&Tab=attachments). Staff are recommending using a complex warrant system based on eligibility and risk factors to designate Community Safety Zones, and to have automated speed enforcement in all such areas. This is for Regional roads only, but staff expect lower-tier municipalities to follow the Region’s lead.  
+* Kitchener is making a [long list of Vision Zero updates](https://www.engagewr.ca/visionzero/news_feed/2024-hot-spot-improvements) this year to address hot spots, notably including raised crosswalks and pedestrian crossovers.  
 * Several of Kitchener’s [road reconstruction projects](https://www.engagewr.ca/roadreconstruction) ongoing this year feature curb-protected bike lanes and continuous sidewalks.  
-* The Region of Waterloo has a [proposed phased plan](https://www.engagewr.ca/benton-and-frederick-cycling) to add bike lanes along Benton and Frederick Streets in Kitchener from Courtland to Lancaster Street. However, phase 1 would feature only on-road painted bike lanes and only outside of the downtown section, with phase 2 scheduled all the way out in 2032\. This came to [Regional council committee](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=f1c44658-b16e-44d4-8ce7-c27a52671e66\&Agenda=Merged\&lang=English\&Item=24\&Tab=attachments) on August 13, with several delegations in support of improving bike infrastructure on this corridor. ([The Record](https://www.therecord.com/news/waterloo-region/kitcheners-benton-frederick-corridor-to-get-painted-bike-lanes-in-2025-cycling-advocates-want-separation/article\_538daf84-ac78-5b8a-98d4-ca373fd14d42.html)). The staff recommendation was approved by committee and will be considered for final approval at Regional Council on August 28\.  
-* The City of Waterloo was ranked \#1 across Ontario cities in a bicycle network analysis by PeopleForBikes ([City of Waterloo](https://www.waterloo.ca/Modules/News/index.aspx?feedId=0d868655-ba17-4efa-988b-1951530c7aec\&newsId=6ca578e1-3c96-4dc2-82f8-a5b9acec5af6)).
+* The Region of Waterloo has a [proposed phased plan](https://www.engagewr.ca/benton-and-frederick-cycling) to add bike lanes along Benton and Frederick Streets in Kitchener from Courtland to Lancaster Street. However, phase 1 would feature only on-road painted bike lanes and only outside of the downtown section, with phase 2 scheduled all the way out in 2032. This came to [Regional council committee](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=f1c44658-b16e-44d4-8ce7-c27a52671e66&Agenda=Merged&lang=English&Item=24&Tab=attachments) on August 13, with several delegations in support of improving bike infrastructure on this corridor. ([The Record](https://www.therecord.com/news/waterloo-region/kitcheners-benton-frederick-corridor-to-get-painted-bike-lanes-in-2025-cycling-advocates-want-separation/article_538daf84-ac78-5b8a-98d4-ca373fd14d42.html)). The staff recommendation was approved by committee and will be considered for final approval at Regional Council on August 28.  
+* The City of Waterloo was ranked #1 across Ontario cities in a bicycle network analysis by PeopleForBikes ([City of Waterloo](https://www.waterloo.ca/Modules/News/index.aspx?feedId=0d868655-ba17-4efa-988b-1951530c7aec&newsId=6ca578e1-3c96-4dc2-82f8-a5b9acec5af6)).
 
 ## Local transit
 
-* Grand River Transit fall service starts on Monday, September 2\. The [service changes](https://www.grt.ca/en/service-updates/service-alerts.aspx) are substantial and include:  
-  * The extension of 15-minute weekday frequency on a number of routes, creating a substantial network of all-day 15 minute frequency on weekdays (outside of summer).   
-  * The return of a limited Route 91 Late Night Loop service Thursday, Friday, and Saturday nights between downtown Kitchener, uptown Waterloo, and the university areas. This is a direct result of advocacy this year\!  
-  * First ever fixed route service to the Region of Waterloo airport \- limited weekday service on a new Route 78 Fountain from Sportsworld Station.  
-  * Removal of some stops, particularly to speed up Route 16\.  
-  * A new Route 62 Speedsville with all day weekday service from Sportsworld to the Cambridge Business Park area.  
+* Grand River Transit fall service starts on Monday, September 2. The [service changes](https://www.grt.ca/en/service-updates/service-alerts.aspx) are substantial and include:
+  * The extension of 15-minute weekday frequency on a number of routes, creating a substantial network of all-day 15 minute frequency on weekdays (outside of summer).
+  * The return of a limited Route 91 Late Night Loop service Thursday, Friday, and Saturday nights between downtown Kitchener, uptown Waterloo, and the university areas. This is a direct result of advocacy this year!
+  * First ever fixed route service to the Region of Waterloo airport - limited weekday service on a new Route 78 Fountain from Sportsworld Station.
+  * Removal of some stops, particularly to speed up Route 16.
+  * A new Route 62 Speedsville with all day weekday service from Sportsworld to the Cambridge Business Park area.
   * Sunday service and later weekday service on several routes.
 
 Elsewhere:
@@ -41,14 +41,14 @@ Elsewhere:
 
 ## Regional transit
 
-* Region of Waterloo staff are [bringing forward](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=d646b7bf-9c51-4fa1-a80b-2b0b682a8c06\&Agenda=Agenda\&lang=English\&Item=23\&Tab=attachments) an initial business case and recommendation for a GO train connection from Cambridge to Toronto via Guelph ([Cambridge Today](https://www.cambridgetoday.ca/local-news/icymi-region-ready-to-advance-cambridge-to-guelph-go-transit-proposal-9335049)). RM Transit [offers commentary](https://www.youtube.com/watch?v=j\_s7OeJq83E).  
+* Region of Waterloo staff are [bringing forward](https://pub-regionofwaterloo.escribemeetings.com/Meeting.aspx?Id=d646b7bf-9c51-4fa1-a80b-2b0b682a8c06&Agenda=Agenda&lang=English&Item=23&Tab=attachments) an initial business case and recommendation for a GO train connection from Cambridge to Toronto via Guelph ([Cambridge Today](https://www.cambridgetoday.ca/local-news/icymi-region-ready-to-advance-cambridge-to-guelph-go-transit-proposal-9335049)). RM Transit [offers commentary](https://www.youtube.com/watch?v=j_s7OeJq83E).  
 * GO Transit is expropriating land for new tracks and a flyover in Georgetown, a key pinch point on the Kitchener line. ([CBC](https://www.cbc.ca/news/canada/kitchener-waterloo/land-expropriation-metrolinx-two-way-all-day-go-kitchener-1.7269827))  
-* The Region of Waterloo bought land for a future Breslau GO train station and nearby development. ([The Record](https://www.therecord.com/news/waterloo-region/region-buys-site-for-future-go-station-in-breslau-this-is-a-milestone-investment/article\_fbeb5269-ee9b-568a-8674-e013f582887e.html))
+* The Region of Waterloo bought land for a future Breslau GO train station and nearby development. ([The Record](https://www.therecord.com/news/waterloo-region/region-buys-site-for-future-go-station-in-breslau-this-is-a-milestone-investment/article_fbeb5269-ee9b-568a-8674-e013f582887e.html))
 
 ## The shape of our cities
 
-* Mike Farwell [writes that removing parking minimums](https://www.therecord.com/opinion/columnists/improving-transit-must-happen-with-parking-minimums-eliminated/article\_89ef3c83-cfe7-5547-b34e-d8f3111fe188.html) around station areas in Kitchener is good, and that transit improvements should go along with it.  
-* The City of Waterloo issues a Request for Proposals for a large affordable housing development at the northeast edge of the city ([City of Waterloo](https://www.waterloo.ca/Modules/News/index.aspx?feedId=0d868655-ba17-4efa-988b-1951530c7aec\&newsId=a6f0ecb1-e926-4ac7-b194-8bd6efbef4b9)).  
+* Mike Farwell [writes that removing parking minimums](https://www.therecord.com/opinion/columnists/improving-transit-must-happen-with-parking-minimums-eliminated/article_89ef3c83-cfe7-5547-b34e-d8f3111fe188.html) around station areas in Kitchener is good, and that transit improvements should go along with it.  
+* The City of Waterloo issues a Request for Proposals for a large affordable housing development at the northeast edge of the city ([City of Waterloo](https://www.waterloo.ca/Modules/News/index.aspx?feedId=0d868655-ba17-4efa-988b-1951530c7aec&newsId=a6f0ecb1-e926-4ac7-b194-8bd6efbef4b9)).  
 * Kitchener is starting up the development of its new official plan ([EngageWR](https://www.engagewr.ca/kitchener2051)).
 
 ---


### PR DESCRIPTION
When rendered by Jekyll, some of these are harmless but several of the ones inside link URLs break the links in the rendered output currently live on tritag.ca.

Removing these backslashes should make these links work.